### PR TITLE
page-changed 1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,23 @@ $ npm i --save page-changed
 
 
 ```js
-// Dependencies
-var Http = require("http")
-  , PageChanged = require("page-changed")
-  ;
+const http = require("http")
+    , PageChanged = require("page-changed")
+    ;
 
 // Constants
 const PORT = 8000;
 
 // Create a http server
-Http.createServer(function (req, res) {
+http.createServer((req, res) => {
     res.end(Math.floor(new Date().getTime() / 1000).toString());
 }).listen(PORT);
 
 // Detect changes
-var pc = new PageChanged({
+let pc = new PageChanged({
     page: "http://localhost:" + PORT
   , interval: 1000
-}, function (err, html) {
+}, (err, html) => {
     console.log(html);
 });
 ```

--- a/example/index.js
+++ b/example/index.js
@@ -1,20 +1,21 @@
-// Dependencies
-var Http = require("http")
-  , PageChanged = require("../lib")
-  ;
+"use strict";
+
+const http = require("http")
+    , PageChanged = require("../lib")
+    ;
 
 // Constants
 const PORT = 8000;
 
 // Create a http server
-Http.createServer(function (req, res) {
+http.createServer((req, res) => {
     res.end(Math.floor(new Date().getTime() / 1000).toString());
 }).listen(PORT);
 
 // Detect changes
-var pc = new PageChanged({
+let pc = new PageChanged({
     page: "http://localhost:" + PORT
   , interval: 1000
-}, function (err, html) {
+}, (err, html) => {
     console.log(html);
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,10 @@
-// Dependencies
-var Ul = require("ul")
-  , Request = null
-  ;
+"use strict";
+
+const Ul = require("ul")
+    , typpy = require("typpy")
+    ;
+
+let Request = null;
 
 /**
  * PageChanged
@@ -20,7 +23,7 @@ var Ul = require("ul")
  */
 var PageChanged = module.exports = function (options, callback) {
 
-    if (this.constructor !== PageChanged) {
+    if (!typpy(this, PageChanged)) {
         return new PageChanged(options, callback);
     }
 
@@ -31,7 +34,7 @@ var PageChanged = module.exports = function (options, callback) {
     }
 
     // Process arguments
-    Ul.merge(options, {
+    options = Ul.merge(options, {
         interval: 5 * 1000
       , request: function (cb) {
             Request = Request || require("request");

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "request": "^2.53.0",
+    "typpy": "^2.3.3",
     "ul": "^2.1.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-changed",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Call a function when the page body is changed.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Fix a bug that appears in strict mode.

`this` is undefined when not calling the function using `new`, so use `typpy` to check if the context is a current instance, otherwise, create one. :boom:
